### PR TITLE
Support for :decimal, :date, :time, :datetime, :naive_datetime, :map, and :array Ecto types

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,6 @@
 {
   "cSpell.words": [
     "struct",
-    "typedstrcut"
+    "typedstruct"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # TypedStructEctoChangeset
 
 TypedStruct plugin to integrate ecto changeset, allow
-to use typedstrcut module like ecto schema module when casting
+to use typedstruct module like ecto schema module when casting
 changeset, embeds and assoc are not yet supported
 
 ## Installation

--- a/lib/typed_struct_ecto_changeset.ex
+++ b/lib/typed_struct_ecto_changeset.ex
@@ -27,40 +27,85 @@ defmodule TypedStructEctoChangeset do
 
       iex> Ecto.Changeset.cast(%TypedStructModule{}, %{"age" => 23, "name" => "John Doe"}, [:age, :name])
       %Ecto.Changeset{}
+
+
+  Supports as many Ecto types as possible including `:decimal`, `:date`,
+  `:time`, `:datetime`, from their corresponding typespecs `Decimal.t()`, etc.
+
+  Also converts `any()`, `term()` or `map()` types in field specifications
+  to `:map`, and list types, like `[integer()]` to e.g. `{:array, :integer}`.
+
+  You can supply a `:usec_times` option to the plugin. If the option is
+  `true`, then `Time.t()`, `DateTime.t()` and `NaiveDateTime.t()` fields
+  will produce the Ecto types `:time_usec`, `:datetime_usec` and
+  `naive_datetime_usec`.
   """
   use TypedStruct.Plugin
 
-  defmacro init(_opts) do
+  defmacro init(opts) do
     quote do
       Module.register_attribute(__MODULE__, :changeset_fields, accumulate: true)
+
+      @usec_times unquote(opts) |> Keyword.get(:usec_times, false)
     end
   end
 
-  def field(name, type, _opts) do
+  def field(name, type, opts) do
     quote do
-      @changeset_fields {unquote(name), unquote(spec_to_type(type))}
+      @changeset_fields {unquote(name), unquote(spec_to_type(type, opts))}
     end
   end
 
-  defp spec_to_type(type) when is_atom(type) do
+  defp spec_to_type(:term, _opts), do: :map
+  defp spec_to_type(:any, _opts), do: :map
+
+  defp spec_to_type(type, _opts) when is_atom(type) do
     type
   end
 
-  defp spec_to_type(type) do
+  defp spec_to_type(type, opts) do
     case type do
+      [array_type] ->
+        {:array, spec_to_type(array_type, opts)}
+
       {:%, _, [{:__aliases__, _, _} = aliases, {:%{}, _, []}]} ->
         aliases
 
       {{:., _, [{:__aliases__, _, _path} = aliases, :t]}, _, []} ->
-        build_in_aliases(aliases)
+        build_in_aliases(aliases, opts)
 
       {atom, _, []} ->
-        atom
+        spec_to_type(atom, opts)
     end
   end
 
-  defp build_in_aliases({:__aliases__, _, [:String]}), do: :string
-  defp build_in_aliases(aliases), do: aliases
+  # Support for more primitive types
+  # https://hexdocs.pm/ecto/Ecto.Schema.html#module-primitive-types
+  defp build_in_aliases({:__aliases__, _, [:String]}, _opts), do: :string
+  defp build_in_aliases({:__aliases__, _, [:Decimal]}, _opts), do: :decimal
+  defp build_in_aliases({:__aliases__, _, [:Date]}, _opts), do: :date
+  defp build_in_aliases({:__aliases__, _, [:Time]}, opts) do
+    if Keyword.get(opts, :usec_times, false) do
+      :time_usec
+    else
+      :time
+    end
+  end
+  defp build_in_aliases({:__aliases__, _, [:DateTime]}, opts) do
+    if Keyword.get(opts, :usec_times, false) do
+      :datetime_usec
+    else
+      :datetime
+    end
+  end
+  defp build_in_aliases({:__aliases__, _, [:NaiveDateTime]}, opts) do
+    if Keyword.get(opts, :usec_times, false) do
+      :naive_datetime_usec
+    else
+      :naive_datetime
+    end
+  end
+  defp build_in_aliases({:__aliases__, _, _} = aliases, _opts), do: aliases
 
   def after_definition(_opts) do
     quote unquote: false do

--- a/lib/typed_struct_ecto_changeset.ex
+++ b/lib/typed_struct_ecto_changeset.ex
@@ -1,16 +1,19 @@
 defmodule TypedStructEctoChangeset do
   @moduledoc """
-  TypedStruct plugin to integrate ecto changeset, allow
-  to use typedstrcut module like ecto schema module when casting
-  changeset, embeds and assoc are not yet supported, but you can use
+  A TypedStruct plugin to integrate ecto changeset, that lets you
+  use a typedstruct module as an Ecto schema module when casting
+  changesets.
+
+  Embeds and assoc are not yet supported, but you can use
   `Ecto.Type` implementation instead
 
-  Module worsk by generating __changeset__ that returns field types
-  and is used by `Ecto.Changeset.cast` to cast types
+  The plugin works by generating a `__changeset__/0` function
+  in the invoking module, which is called by `Ecto.Changeset.cast/3`
+  to cast types.
 
   ## Examples
 
-  if module exists:
+  If this module is defined:
   ```
   defmodule TypedStructModule do
     use TypedStruct
@@ -28,6 +31,7 @@ defmodule TypedStructEctoChangeset do
       iex> Ecto.Changeset.cast(%TypedStructModule{}, %{"age" => 23, "name" => "John Doe"}, [:age, :name])
       %Ecto.Changeset{}
 
+  ## Notes
 
   Supports as many Ecto types as possible including `:decimal`, `:date`,
   `:time`, `:datetime`, from their corresponding typespecs `Decimal.t()`, etc.
@@ -39,6 +43,20 @@ defmodule TypedStructEctoChangeset do
   `true`, then `Time.t()`, `DateTime.t()` and `NaiveDateTime.t()` fields
   will produce the Ecto types `:time_usec`, `:datetime_usec` and
   `naive_datetime_usec`.
+
+  For example:
+  ```
+  defmodule TypedStructModule do
+    use TypedStruct
+
+    typedstruct do
+      plugin TypedStructEctoChangeset, usec_times: true
+
+      field :time_with_usec, Time.t()
+      field :updated_at_with_usec, NaiveDateTime.t()
+    end
+  end
+  ```
   """
   use TypedStruct.Plugin
 

--- a/test/typedstruct_ecto_test.exs
+++ b/test/typedstruct_ecto_test.exs
@@ -22,8 +22,33 @@ defmodule TypedStructEctoChangesetTest do
       field :binary, binary()
       field :string1, :string
       field :string2, String.t()
+      field :decimal1, Decimal.t()
+      field :date1, Date.t()
+      field :time1, Time.t()
+      field :datetime1, DateTime.t()
+      field :datetime2, NaiveDateTime.t()
+      field :any1, any()
+      field :term1, term()
+      field :list1, [integer()]
+      field :list2, [String.t()]
+      field :list3, [any()]
+      field :list4, [term()]
       field :struct1, %TypedStructEctoChangesetTest.Struct{}
       field :struct2, TypedStructEctoChangesetTest.Struct.t()
+    end
+  end
+
+  defmodule SampleUsec do
+    @moduledoc false
+
+    use TypedStruct
+
+    typedstruct do
+      plugin TypedStructEctoChangeset, usec_times: true
+
+      field :time1, Time.t()
+      field :datetime1, DateTime.t()
+      field :datetime2, NaiveDateTime.t()
     end
   end
 
@@ -47,12 +72,68 @@ defmodule TypedStructEctoChangesetTest do
     assert Map.get(Sample.__changeset__(), :string2) == :string
   end
 
+  test "Decimal.t() format" do
+    assert Map.get(Sample.__changeset__(), :decimal1) == :decimal
+  end
+
+  test "Date.t() format" do
+    assert Map.get(Sample.__changeset__(), :date1) == :date
+  end
+
+  test "Time.t() format" do
+    assert Map.get(Sample.__changeset__(), :time1) == :time
+  end
+
+  test "DateTime.t() format" do
+    assert Map.get(Sample.__changeset__(), :datetime1) == :datetime
+  end
+
+  test "NaiveDateTime.t() format" do
+    assert Map.get(Sample.__changeset__(), :datetime2) == :naive_datetime
+  end
+
+  test "any() format is a :map" do
+    assert Map.get(Sample.__changeset__(), :any1) == :map
+  end
+
+  test "term() format is a :map" do
+    assert Map.get(Sample.__changeset__(), :term1) == :map
+  end
+
+  test "[integer()] format is an {:array, :integer}" do
+    assert Map.get(Sample.__changeset__(), :list1) == {:array, :integer}
+  end
+
+  test "[String.t()] format is an {:array, :string}" do
+    assert Map.get(Sample.__changeset__(), :list2) == {:array, :string}
+  end
+
+  test "[any()] format is an {:array, :map}" do
+    assert Map.get(Sample.__changeset__(), :list3) == {:array, :map}
+  end
+
+  test "[term()] format is an {:array, :map}" do
+    assert Map.get(Sample.__changeset__(), :list4) == {:array, :map}
+  end
+
   test "struct using %{} format" do
     assert Map.get(Sample.__changeset__(), :struct1) == TypedStructEctoChangesetTest.Struct
   end
 
   test "struct using .t() format" do
     assert Map.get(Sample.__changeset__(), :struct2) == TypedStructEctoChangesetTest.Struct
+  end
+
+  test "Time.t() format with usec option" do
+    assert Map.get(SampleUsec.__changeset__(), :time1) == :time_usec
+  end
+
+  test "DateTime.t() format with usec option" do
+    assert Map.get(SampleUsec.__changeset__(), :datetime1) == :datetime_usec
+  end
+
+  test "NaiveDateTime.t() format with usec option" do
+    assert Map.get(SampleUsec.__changeset__(), :datetime2) == :naive_datetime_usec
   end
 
   test "cast with ecto" do


### PR DESCRIPTION
This pull request adds a few more cases for parsing field typespecs. There is also an option, `:usec_times`, to create `_usec` versions of any time fields in the struct specification.