### PR TITLE
Fix dateimte ecto type alias

### DIFF
--- a/lib/typed_struct_ecto_changeset.ex
+++ b/lib/typed_struct_ecto_changeset.ex
@@ -116,9 +116,9 @@ defmodule TypedStructEctoChangeset do
 
   defp build_in_aliases({:__aliases__, _, [:DateTime]}, opts) do
     if Keyword.get(opts, :usec_times, false) do
-      :datetime_usec
+      :utc_datetime_usec
     else
-      :datetime
+      :utc_datetime
     end
   end
 


### PR DESCRIPTION
Ecto does not support `datetime` and for DateTime struct it only supports it when timezone is set to utc. The underlying type is `utc_datetime`.